### PR TITLE
navigates to the loading page when the app is minimised

### DIFF
--- a/Cuisinele/app/src/main/java/com/example/cuisinele/Cuisinele.kt
+++ b/Cuisinele/app/src/main/java/com/example/cuisinele/Cuisinele.kt
@@ -48,8 +48,15 @@ class Cuisinele : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         enterClicked()
-//        toggleGuesses()
         populateHint()
+    }
+
+    /**
+     * If the application is minimised, we should navigate to the LoadingPage in case the day ticks over before the app is opened again.
+     */
+    override fun onPause() {
+        super.onPause()
+        findNavController().navigate(R.id.LoadingPage)
     }
 
     /**
@@ -214,21 +221,5 @@ class Cuisinele : Fragment() {
         super.onDestroyView()
         _binding = null
     }
-
-
-//    /**
-//     * Method sets up the show/hide guess button.
-//     */
-//    private fun toggleGuesses() {
-//        binding.displayGuessButton.setOnClickListener {
-//            if (binding.guessDisplay.visibility == View.INVISIBLE) {
-//                binding.guessDisplay.visibility = View.VISIBLE
-//                binding.displayGuessButton.text = getString(R.string.HideGuess)
-//            } else {
-//                binding.guessDisplay.visibility = View.INVISIBLE
-//                binding.displayGuessButton.text = getString(R.string.DisplayGuess)
-//            }
-//        }
-//    }
 
 }


### PR DESCRIPTION
If the app was minimized, it would not update the dish properly - this has been changed so if it is minimized from the main page, it will navigate to the loading page